### PR TITLE
Dependency on the jsonnet vendor and gojsontoyaml

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 JSONNET_FMT := jsonnet fmt -n 2 --max-blank-lines 2 --string-style s --comment-style s
 
+GOPATH ?= `$(pwd)`
+
 JSONNET_BIN := $(GOPATH)/bin/jsonnet
 JB_BINARY := $(GOPATH)/bin/jb
 


### PR DESCRIPTION
I have tried to run a simple `make deploy`. First problem was my GOPATH was blank (even though the golang was installed). After that was fixed, I needed to actually run `make vendor` before I could even consider running `make deploy`. I also needed to add my GOPATH/bin directory to path as it did not find gojsontoyaml otherwise
`export PATH=$PATH:$GOPATH/bin`

Error I was solving:
```
$ make deploy
Installing jsonnet
rm -rf manifests
./scripts/build.sh main.jsonnet /home/xzy/cluster-monitoring/bin/jsonnet
using jsonnet from arg
+ set -o pipefail
+ rm -rf manifests
+ mkdir manifests
+ /home/xyz/cluster-monitoring/bin/jsonnet -J vendor -m manifests main.jsonnet
+ xargs '-I{}' sh -c 'cat {} | gojsontoyaml > {}.yaml; rm -f {}' -- '{}'
RUNTIME ERROR: couldn't open import "kube-prometheus/kube-prometheus.libsonnet": no match locally or in the Jsonnet library paths
	main.jsonnet:12:13-63	thunk <kp> from <$>
	main.jsonnet:30:81-83	
	<std>:1268:24-25	thunk from <function <anonymous>>
	<std>:1268:5-33	function <anonymous>
	main.jsonnet:30:64-99	$
		
		
	During evaluation	

make: *** [Makefile:12: manifests] Error 1
```