### PR TITLE
Fixed broken expression concatenation

### DIFF
--- a/utils.libsonnet
+++ b/utils.libsonnet
@@ -49,7 +49,7 @@ local vars = import 'vars.jsonnet';
 
       local c = clusterRole.new()
             + (if labels != null then clusterRole.mixin.metadata.withLabels(labels) else {})
-            + clusterRole.mixin.metadata.withName(name) +
+            + clusterRole.mixin.metadata.withName(name)
             + clusterRole.withRules(rules);
       c
     ),
@@ -59,7 +59,7 @@ local vars = import 'vars.jsonnet';
       local clusterRoleBinding = k.rbac.v1.clusterRoleBinding;
 
       clusterRoleBinding.new()
-      + clusterRoleBinding.mixin.metadata.withName(name) +
+      + clusterRoleBinding.mixin.metadata.withName(name)
       + (if labels != null then clusterRoleBinding.mixin.metadata.withLabels(labels) else {})
       + clusterRoleBinding.mixin.roleRef.withApiGroup('rbac.authorization.k8s.io')
       + clusterRoleBinding.mixin.roleRef.withName(clusterRole)


### PR DESCRIPTION
Tried to run `make` with `armExporter` exporter module enabled.

Build broke with
```
RUNTIME ERROR: Unexpected type object, expected number
	utils.libsonnet:53:13-43	thunk <c> from <function <anonymous>>
	utils.libsonnet:54:7-8	function <anonymous>
	arm_exporter.jsonnet:(22:7)-(31:15)	object <anonymous>
	main.jsonnet:34:47-68	object <anonymous>
	During manifestation
```
and
```
RUNTIME ERROR: Unexpected type object, expected number
	utils.libsonnet:63:7-94	function <anonymous>
	arm_exporter.jsonnet:34:7-109	object <anonymous>
	main.jsonnet:34:47-68	object <anonymous>
	During manifestation
```
due to broken expression concatenation. This PR fixes this.

