### PR TITLE
corrected file path for the prometheus ingress config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,4 +64,4 @@ change_suffix:       ## Changes suffix for the ingress
 	@echo "Ingress IPs changed to [service].${IP}.nip.io"
 	${K3S} kubectl apply -f manifests/ingress-alertmanager.yaml
 	${K3S} kubectl apply -f manifests/ingress-grafana.yaml
-	${K3S} kubectl apply -f manifests/ingress-prometheus-k8s.yaml
+	${K3S} kubectl apply -f manifests/ingress-prometheus.yaml


### PR DESCRIPTION
The make task is targeting a file that is presumably renamed

```
✔ ~/development/raspberry_patch/cluster-monitoring [master|✚ 8…6] $ make change_suffix IP=192.168.1.104
Ingress IPs changed to [service].192.168.1.104.nip.io
kubectl apply -f manifests/ingress-alertmanager.yaml
ingress.extensions/alertmanager-main configured
kubectl apply -f manifests/ingress-grafana.yaml
ingress.extensions/grafana configured
kubectl apply -f manifests/ingress-prometheus-k8s.yaml
error: the path "manifests/ingress-prometheus-k8s.yaml" does not exist
Makefile:63: recipe for target 'change_suffix' failed
make: *** [change_suffix] Error 1
```