### PR TITLE
Issue #39: Add affinity for arm/arm64 support for arm-exporter.

### DIFF
--- a/arm_exporter.jsonnet
+++ b/arm_exporter.jsonnet
@@ -73,7 +73,7 @@ local utils = import 'utils.libsonnet';
       daemonset.mixin.spec.selector.withMatchLabels(podLabels) +
       daemonset.mixin.spec.template.metadata.withLabels(podLabels) +
       daemonset.mixin.spec.template.spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.withNodeSelectorTerms([{ matchExpressions: [{ key: 'kubernetes.io/arch', operator: 'In', values: ['arm', 'arm64'] }] }]) +
-      daemonset.mixin.spec.template.spec.withTolerations([{ operator: 'Exists' }]) +
+      daemonset.mixin.spec.template.spec.withTolerations([{ 'operator': 'Exists' }]) +
       daemonset.mixin.spec.template.spec.withServiceAccountName('arm-exporter') +
       daemonset.mixin.spec.template.spec.withContainers(c),
 

--- a/arm_exporter.jsonnet
+++ b/arm_exporter.jsonnet
@@ -72,7 +72,7 @@ local utils = import 'utils.libsonnet';
       daemonset.mixin.metadata.withLabels(podLabels) +
       daemonset.mixin.spec.selector.withMatchLabels(podLabels) +
       daemonset.mixin.spec.template.metadata.withLabels(podLabels) +
-      daemonset.mixin.spec.template.spec.withNodeSelector({ 'beta.kubernetes.io/arch': 'arm64' }) +
+      daemonset.mixin.spec.template.spec.withAffinity({'nodeAffinity':{'requiredDuringSchedulingIgnoredDuringExecution':{'nodeSelectorTerms':[{'matchExpressions':[{'key':'kubernetes.io/arch','operator':'In','values':['arm','arm64']}]}]}}}) +
       daemonset.mixin.spec.template.spec.withServiceAccountName('arm-exporter') +
       daemonset.mixin.spec.template.spec.withContainers(c),
 

--- a/arm_exporter.jsonnet
+++ b/arm_exporter.jsonnet
@@ -72,7 +72,8 @@ local utils = import 'utils.libsonnet';
       daemonset.mixin.metadata.withLabels(podLabels) +
       daemonset.mixin.spec.selector.withMatchLabels(podLabels) +
       daemonset.mixin.spec.template.metadata.withLabels(podLabels) +
-      daemonset.mixin.spec.template.spec.withAffinity({'nodeAffinity':{'requiredDuringSchedulingIgnoredDuringExecution':{'nodeSelectorTerms':[{'matchExpressions':[{'key':'kubernetes.io/arch','operator':'In','values':['arm','arm64']}]}]}}}) +
+      daemonset.mixin.spec.template.spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.withNodeSelectorTerms([{ matchExpressions: [{ key: 'kubernetes.io/arch', operator: 'In', values: ['arm', 'arm64'] }] }]) +
+      daemonset.mixin.spec.template.spec.withTolerations([{ operator: 'Exists' }]) +
       daemonset.mixin.spec.template.spec.withServiceAccountName('arm-exporter') +
       daemonset.mixin.spec.template.spec.withContainers(c),
 


### PR DESCRIPTION
Closes #39.﻿

Note that this currently results in the following error when running `make`:

```
+ xargs '-I{}' sh -c 'cat {} | $(go env GOPATH)/bin/gojsontoyaml > {}.yaml; rm -f {}' -- '{}'
RUNTIME ERROR: Field does not exist: withAffinity
	arm_exporter.jsonnet:75:7-54	object <anonymous>
	main.jsonnet:36:47-68	object <anonymous>
	During manifestation
```

I am not an expert at jsonnet, but I'm guessing there needs to be a new util added to `utils.libsonnet`?

Ultimately, it needs to add the following `spec.affinity` in `armexporter-daemonset.yaml`:

```yaml
    spec:                                                                                 
      affinity:                                                                           
        nodeAffinity:                                                  
          requiredDuringSchedulingIgnoredDuringExecution:              
            nodeSelectorTerms:                                         
            - matchExpressions:                                        
              - key: kubernetes.io/arch                                
                operator: In                                           
                values:                                                
                - arm                                                  
                - arm64 
```