### PR TITLE
Configure grafana with optional env variables

### DIFF
--- a/base_operator_stack.jsonnet
+++ b/base_operator_stack.jsonnet
@@ -59,6 +59,7 @@ local vars = import 'vars.jsonnet';
         },
       },
       plugins: vars.grafana.plugins,
+      env: vars.grafana.env
     },
   },
   //---------------------------------------

--- a/vars.jsonnet
+++ b/vars.jsonnet
@@ -79,5 +79,7 @@
     // Plugins to be installed at runtime.
     //Ex. plugins: ['grafana-piechart-panel', 'grafana-clock-panel'],
     plugins: [],
+    //Ex. env: [ { name: 'http_proxy', value: 'host:8080' } ]
+    env: []
   },
 }


### PR DESCRIPTION
- allow adding environment variables to the grafana deployment. the main use case for this is to allow plugin download when behind a proxy.

fixes #72 