### PR TITLE
Added securityContext.priviledged = true to fix RPi GPU temp issue

### DIFF
--- a/modules/arm_exporter.jsonnet
+++ b/modules/arm_exporter.jsonnet
@@ -49,6 +49,7 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
           '/bin/rpi_exporter',
           '--web.listen-address=127.0.0.1:9243',
         ]) +
+        container.mixin.securityContext.withPrivileged(true) +
         container.mixin.resources.withRequests({ cpu: '50m', memory: '50Mi' }) +
         container.mixin.resources.withLimits({ cpu: '100m', memory: '100Mi' });
 


### PR DESCRIPTION
This will fix the issue where the vcgencmd command returned 255 as it was not able to find the /dev special files it needed.
By making it a privileged container, /dev is mounted and the temp of the GPU for the PIs is exported.