### PR TITLE
Fix for #110 Upgrade Ingress API versions to networking.k8s.io/v due to deprecation

### DIFF
--- a/manifests/ingress-alertmanager.yaml
+++ b/manifests/ingress-alertmanager.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: alertmanager-main

--- a/manifests/ingress-grafana.yaml
+++ b/manifests/ingress-grafana.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: grafana

--- a/manifests/ingress-prometheus.yaml
+++ b/manifests/ingress-prometheus.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: prometheus-k8s


### PR DESCRIPTION
Fixes #110: Warning: extensions/v1beta1 Ingress is deprecated in v1.14+, unavailable in v1.22+; use networking.k8s.io/v1 Ingress