### PR TITLE
Patched ingress to resolve 'unkown spec serviceName'

### DIFF
--- a/manifests/ingress-alertmanager.yaml
+++ b/manifests/ingress-alertmanager.yaml
@@ -9,9 +9,12 @@ spec:
     http:
       paths:
       - backend:
-          serviceName: alertmanager-main
-          servicePort: web
+          service:
+            name: alertmanager-main
+            port:
+              name: web
         path: /
+        pathType: Prefix
   tls:
   - hosts:
     - alertmanager.192.168.1.15.nip.io

--- a/manifests/ingress-grafana.yaml
+++ b/manifests/ingress-grafana.yaml
@@ -9,9 +9,12 @@ spec:
     http:
       paths:
       - backend:
-          serviceName: grafana
-          servicePort: http
+          service:
+            name: grafana
+            port:
+              name: http
         path: /
+        pathType: Prefix
   tls:
   - hosts:
     - grafana.192.168.1.15.nip.io

--- a/manifests/ingress-prometheus.yaml
+++ b/manifests/ingress-prometheus.yaml
@@ -9,9 +9,12 @@ spec:
     http:
       paths:
       - backend:
-          serviceName: prometheus-k8s
-          servicePort: web
+          service:
+            name: prometheus-k8s
+            port:
+              name: web
         path: /
+        pathType: Prefix
   tls:
   - hosts:
     - prometheus.192.168.1.15.nip.io


### PR DESCRIPTION
Patches the ingress so that Make no longer fails with errors similar to 
```
Error from server (Invalid): error when creating "manifests/ingress-alertmanager.yaml": Ingress.extensions "alertmanager-main" is invalid: spec.rules[0].http.paths[0].pathType: Required value: pathType must be specified
```
and 
```
[error validating "manifests/ingress-grafana.yaml": error validating data: [ValidationError(Ingress.spec.rules[0].http.paths[0].backend): unknown field "serviceName" in io.k8s.api.networking.v1.IngressBackend, ValidationError(Ingress.spec.rules[0].http.paths[0].backend): unknown field "servicePort" in io.k8s.api.networking.v1.IngressBackend]; if you choose to ignore these errors, turn validation off with --validate=false, error validating "manifests/ingress-prometheus.yaml"
```

I also added in `pathType: Prefix` since `pathType` is required to be specified.