### PR TITLE
Fix speedtest grafana dashboard not working on default grafana

### DIFF
--- a/grafana-dashboards/speedtest-exporter-dashboard.json
+++ b/grafana-dashboards/speedtest-exporter-dashboard.json
@@ -1,34 +1,4 @@
 {
-  "__inputs": [
-    {
-      "name": "DS_PROMETHEUS",
-      "label": "Prometheus",
-      "description": "",
-      "type": "datasource",
-      "pluginId": "prometheus",
-      "pluginName": "Prometheus"
-    }
-  ],
-  "__requires": [
-    {
-      "type": "grafana",
-      "id": "grafana",
-      "name": "Grafana",
-      "version": "7.2.1"
-    },
-    {
-      "type": "panel",
-      "id": "graph",
-      "name": "Graph",
-      "version": ""
-    },
-    {
-      "type": "datasource",
-      "id": "prometheus",
-      "name": "Prometheus",
-      "version": "1.0.0"
-    }
-  ],
   "annotations": {
     "list": [
       {
@@ -37,7 +7,7 @@
         "enable": true,
         "hide": true,
         "iconColor": "rgba(0, 211, 255, 1)",
-       "name": "Annotations & Alerts",
+        "name": "Annotations & Alerts",
         "type": "dashboard"
       }
     ]
@@ -45,7 +15,6 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "id": null,
   "links": [],
   "panels": [
     {
@@ -53,7 +22,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_PROMETHEUS}",
+      "datasource": "prometheus",
       "fieldConfig": {
         "defaults": {
           "custom": {}
@@ -83,28 +52,33 @@
       },
       "lines": true,
       "linewidth": 1,
-      "nullPointMode": "null",
+      "nullPointMode": "connected",
       "options": {
-        "alertThreshold": true
+        "alertThreshold": true,
+        "dataLinks": []
       },
       "percentage": false,
-      "pluginVersion": "7.2.1",
+      "pluginVersion": "7.0.3",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
       "seriesOverrides": [],
       "spaceLength": 10,
       "stack": false,
-      "steppedLine": false,
+      "steppedLine": true,
       "targets": [
         {
           "expr": "speedtest_ping_latency_milliseconds",
+          "format": "time_series",
+          "instant": false,
           "interval": "",
           "legendFormat": "Ping (ms)",
           "refId": "A"
         },
         {
           "expr": "speedtest_jitter_latency_milliseconds",
+          "format": "time_series",
+          "instant": false,
           "interval": "",
           "legendFormat": "Jitter (ms)",
           "refId": "B"
@@ -158,7 +132,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_PROMETHEUS}",
+      "datasource": "prometheus",
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -188,9 +162,10 @@
       },
       "lines": true,
       "linewidth": 1,
-      "nullPointMode": "null",
+      "nullPointMode": "connected",
       "options": {
-        "alertThreshold": true
+        "alertThreshold": true,
+        "dataLinks": []
       },
       "percentage": false,
       "pluginVersion": "7.2.1",
@@ -200,10 +175,12 @@
       "seriesOverrides": [],
       "spaceLength": 10,
       "stack": false,
-      "steppedLine": false,
+      "steppedLine": true,
       "targets": [
         {
           "expr": "speedtest_download_bits_per_second*10^-6",
+          "format": "time_series",
+          "instant": false,
           "interval": "",
           "legendFormat": "Download Speed (Mbits/s)",
           "refId": "A"
@@ -258,7 +235,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_PROMETHEUS}",
+      "datasource": "prometheus",
       "fieldConfig": {
         "defaults": {
           "custom": {}
@@ -287,9 +264,10 @@
       },
       "lines": true,
       "linewidth": 1,
-      "nullPointMode": "null",
+      "nullPointMode": "connected",
       "options": {
-        "alertThreshold": true
+        "alertThreshold": true,
+        "dataLinks": []
       },
       "percentage": false,
       "pluginVersion": "7.2.1",
@@ -299,10 +277,11 @@
       "seriesOverrides": [],
       "spaceLength": 10,
       "stack": false,
-      "steppedLine": false,
+      "steppedLine": true,
       "targets": [
         {
           "expr": "speedtest_upload_bits_per_second*10^-6",
+          "format": "time_series",
           "interval": "",
           "legendFormat": "Upload Speed (Mbits/s)",
           "refId": "A"
@@ -354,8 +333,8 @@
       }
     }
   ],
-  "refresh": false,
-  "schemaVersion": 26,
+  "refresh": "15m",
+  "schemaVersion": 25,
   "style": "dark",
   "tags": [],
   "templating": {
@@ -369,5 +348,5 @@
   "timezone": "",
   "title": "Speedtest Dashboard",
   "uid": "-fs18ztMz",
-  "version": 4
+  "version": 1
 }


### PR DESCRIPTION
Update the Speedtest Grafana Dashboard to work with the default grafana version included in this repository.
This is done by changing the data source to directly reference `prometheus`.
Most other changes are required to keep the visuals the same as in the previous version.
This PR also adds a 15 minute auto refresh to the grafana dashboard.