### PR TITLE
Use renamed kube-prometheus main branch

### DIFF
--- a/jsonnetfile.json
+++ b/jsonnetfile.json
@@ -8,7 +8,7 @@
           "subdir": "jsonnet/kube-prometheus"
         }
       },
-      "version": "master"
+      "version": "main"
     }
   ],
   "legacyImports": true


### PR DESCRIPTION
The kube-prometheus project changed default branch from `master` to `main`. As such it would break the `update_libs` target from the `Makefile`
See this PR for details:
https://github.com/prometheus-operator/kube-prometheus/pull/1491