### PR TITLE
validate go version during `make vendor`

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -151,7 +151,7 @@ The content of this project consists of a set of jsonnet files making up a libra
 
 ### Pre-reqs
 
-The project requires json-bundler and the jsonnet compiler. The Makefile does the heavy-lifting of installing them. You need [Go](https://golang.org/dl/) already installed:
+The project requires json-bundler and the jsonnet compiler. The Makefile does the heavy-lifting of installing them. You need [Go](https://golang.org/dl/) (version 1.18 minimum) already installed:
 
 ```bash
 git clone https://github.com/carlosedp/cluster-monitoring


### PR DESCRIPTION
I had some trouble running `make vendor` initially due to `apt install go` installing golang version 1.15 which does not support the `go install ...` calls done during the build process so I added a check in the Makefile to alert users. I also added a minimum version in the readme where you callout that go is required.

I documented my initial troubles in #172 