### PR TITLE
Fix xargs: command line cannot be assembled, too long

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -20,6 +20,8 @@ rm -rf manifests
 mkdir -p manifests/setup
 
 # optional, but we would like to generate yaml, not json
-$JSONNET_BIN -J vendor -m manifests "${1-example.jsonnet}" | xargs -I{} sh -c 'cat {} | $(go env GOPATH)/bin/gojsontoyaml > {}.yaml; rm -f {}' -- {}
+for file in $(find manifests -type f ! -name '*.yaml'); do
+    cat "$file" | $(go env GOPATH)/bin/gojsontoyaml > "$file.yaml" && rm -f "$file"
+done
 # Clean-up json files from manifests dir
 find manifests -type f ! -name '*.yaml' -delete


### PR DESCRIPTION
Hello there!

I was getting this issue whenever I wanted to update the values with the `make` command:

```bash
$ make                                                                           
rm -rf manifests
./scripts/build.sh main.jsonnet /Users/yelopez/go/bin/jsonnet
using jsonnet from arg
+ set -o pipefail
+ rm -rf manifests
+ mkdir -p manifests/setup
+ /Users/yelopez/go/bin/jsonnet -J vendor -m manifests main.jsonnet
+ xargs '-I{}' sh -c 'cat {} | $(go env GOPATH)/bin/gojsontoyaml > {}.yaml; rm -f {}' -- '{}'
xargs: command line cannot be assembled, too long
make: *** [manifests] Error 1
```

Sending a PR that solved the issue for me.